### PR TITLE
Initialize Spelling App skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-please help to create reactjs ui with .net 8 minimal api project. this project is to help kids to practice spellings test. 
+# Spelling App
 
-feature:
-1. user upload spelling test, usually image with 10 words. need to cater for multiple languges like chinese, english and malay. use openai to extract words.
-2. review by user and save as one lesson
-3. start lesson by understand the word, with small story and an image. using openai to generate
-4. next is listen, click big icon to listen the word.
-5. next is speaking, click big icon to speak and give mark. using openai to give mark.
-6. next is writing, create 3 line box to handwriting practice for english and malay. chinese character handwriting box for chinese charcter. Give mark via openai for most looks like word.
-7. next is repeat push notification based on memory curve theory. you may have short story to explain why repeat is important. 
-8. pop up done the lesson, good job animation. 
+This repository contains a .NET 8 minimal API and a React frontend to help kids practice spellings.
 
-you acting like UIUX design make this application attractive to kids with colorful design. refine this requirements to me # spelling-app
+## Backend
+
+The backend is located in the `SpellingApi` folder and exposes minimal endpoints for lessons:
+
+- `POST /api/lessons/upload` – upload an image and extract words (placeholder for OpenAI OCR).
+- `POST /api/lessons` – save or update a lesson.
+- `GET /api/lessons/{id}` – retrieve a lesson with generated content.
+- `POST /api/lessons/{id}/speech` – grade speech result.
+- `POST /api/lessons/{id}/handwriting` – grade handwriting result.
+
+The solution file `SpellingApp.sln` includes the API project.
+
+## Frontend
+
+The React app resides in `frontend/spelling-ui`. It contains a simple step-based UI and service worker for push notifications.
+
+The application steps are:
+1. upload ➜ 2. review ➜ 3. story ➜ 4. listen ➜ 5. speak ➜ 6. write ➜ 7. repeat.
+
+API calls are implemented in `src/api.js`.
+
+> **Note:** This repository contains only skeleton code and does not fetch dependencies or run build scripts in this environment.

--- a/SpellingApi/Program.cs
+++ b/SpellingApi/Program.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapPost("/api/lessons/upload", async (HttpRequest request) =>
+{
+    // Placeholder for OpenAI OCR integration
+    return Results.Ok(new { words = new[] { "example" } });
+});
+
+app.MapPost("/api/lessons", (Lesson lesson) =>
+{
+    // Placeholder for saving lesson
+    return Results.Ok(lesson);
+});
+
+app.MapGet("/api/lessons/{id}", (int id) =>
+{
+    // Placeholder for retrieving lesson
+    return Results.Ok(new Lesson { Id = id, Words = new[] { "example" } });
+});
+
+app.MapPost("/api/lessons/{id}/speech", (int id, SpeechResult result) =>
+{
+    // Placeholder for OpenAI speech grading
+    return Results.Ok();
+});
+
+app.MapPost("/api/lessons/{id}/handwriting", (int id, HandwritingResult result) =>
+{
+    // Placeholder for OpenAI handwriting grading
+    return Results.Ok();
+});
+
+app.Run();
+
+record Lesson
+{
+    public int Id { get; set; }
+    public string[] Words { get; set; } = Array.Empty<string>();
+    public string? Metadata { get; set; }
+}
+
+record SpeechResult
+{
+    public string AudioBase64 { get; set; } = string.Empty;
+}
+
+record HandwritingResult
+{
+    public string ImageBase64 { get; set; } = string.Empty;
+}

--- a/SpellingApi/SpellingApi.csproj
+++ b/SpellingApi/SpellingApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/SpellingApp.sln
+++ b/SpellingApp.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0
+MinimumVisualStudioVersion = 17.0.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpellingApi", "SpellingApi/SpellingApi.csproj", "{8A4D62C8-7794-4A0C-85AB-123456789ABC}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {8A4D62C8-7794-4A0C-85AB-123456789ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {8A4D62C8-7794-4A0C-85AB-123456789ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {8A4D62C8-7794-4A0C-85AB-123456789ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {8A4D62C8-7794-4A0C-85AB-123456789ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/frontend/spelling-ui/package.json
+++ b/frontend/spelling-ui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "spelling-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/spelling-ui/public/index.html
+++ b/frontend/spelling-ui/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Spelling App</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../src/serviceWorker.js"></script>
+</body>
+</html>

--- a/frontend/spelling-ui/public/sw.js
+++ b/frontend/spelling-ui/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('push', event => {
+  const data = event.data?.text() || 'Review your spelling lesson!';
+  event.waitUntil(
+    self.registration.showNotification('Spelling App', {
+      body: data,
+    })
+  );
+});

--- a/frontend/spelling-ui/src/App.css
+++ b/frontend/spelling-ui/src/App.css
@@ -1,0 +1,10 @@
+.App {
+  text-align: center;
+  padding: 2rem;
+  background-color: #f5f5f5;
+}
+
+button {
+  font-size: 1.5rem;
+  padding: 1rem;
+}

--- a/frontend/spelling-ui/src/App.js
+++ b/frontend/spelling-ui/src/App.js
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import './App.css';
+
+function App() {
+  const steps = ['upload', 'review', 'story', 'listen', 'speak', 'write', 'repeat'];
+  const [step, setStep] = useState(steps[0]);
+
+  const next = () => {
+    const idx = steps.indexOf(step);
+    setStep(steps[(idx + 1) % steps.length]);
+  };
+
+  return (
+    <div className="App">
+      <h1>Step: {step}</h1>
+      <button onClick={next}>Next</button>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/spelling-ui/src/api.js
+++ b/frontend/spelling-ui/src/api.js
@@ -1,0 +1,25 @@
+const API_BASE = '/api';
+
+export async function uploadLessonImage(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_BASE}/lessons/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  return res.json();
+}
+
+export async function saveLesson(lesson) {
+  const res = await fetch(`${API_BASE}/lessons`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(lesson),
+  });
+  return res.json();
+}
+
+export async function getLesson(id) {
+  const res = await fetch(`${API_BASE}/lessons/${id}`);
+  return res.json();
+}

--- a/frontend/spelling-ui/src/index.js
+++ b/frontend/spelling-ui/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+import { register } from './serviceWorker';
+
+ReactDOM.render(<App />, document.getElementById('root'));
+register();

--- a/frontend/spelling-ui/src/serviceWorker.js
+++ b/frontend/spelling-ui/src/serviceWorker.js
@@ -1,0 +1,5 @@
+export function register() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
+}


### PR DESCRIPTION
## Summary
- set up minimal SpellingApi project with lesson endpoints
- create SpellingApp solution
- scaffold React app under `frontend/spelling-ui` with basic step flow and API helpers
- document project structure in README

## Testing
- `npx create-react-app spelling-ui` *(fails: 403 Forbidden - GET https://registry.npmjs.org/create-react-app)*

------
https://chatgpt.com/codex/tasks/task_e_6859725051ac83309835b43d2320e51d